### PR TITLE
Provide more function prototypes for improved C99 compatibility

### DIFF
--- a/priv/c_src/gtknode.h
+++ b/priv/c_src/gtknode.h
@@ -20,9 +20,11 @@ gboolean gn_glade_init(char *filename);
 
 /*   marshalling functions (gtknode_marshal.c) */
 void gn_wrap_ans(char* tag, ei_x_buff* xbuf);
+void gn_wrap_reply(char* tag, ei_x_buff* xbuf);
 void gn_enc_1_error(ei_x_buff *xbuf, char *err);
 void gn_enc_2_error(ei_x_buff *xbuf, char *err);
 
+void gn_put_atom(ei_x_buff *xbuf, char *p);
 void gn_put_tuple(ei_x_buff *xbuf, int N);
 void gn_put_void(ei_x_buff *xbuf);
 void gn_put_pid(ei_x_buff *xbuf, erlang_pid *p);

--- a/priv/c_src/gtknode_marshal.c
+++ b/priv/c_src/gtknode_marshal.c
@@ -1,6 +1,9 @@
 #include "gtknode.h"
+#include <ctype.h>
 #include <string.h>
 #include <stdlib.h>
+
+static gboolean gn_get_arg_gtype(ei_x_buff *XBUF, char *B, int *I, GType *gt);
 
 static void hash_init() {
   extern GHashTable* ghash;
@@ -401,7 +404,7 @@ gboolean gn_get_arg_list(ei_x_buff *XBUF, char *B, int *I,
   return TRUE;
 }
 
-gboolean gn_get_arg_gtype(ei_x_buff *XBUF, char *B, int *I, GType *gt){
+static gboolean gn_get_arg_gtype(ei_x_buff *XBUF, char *B, int *I, GType *gt){
   gchar type_str[MAXATOMLEN+1];
 
   if ( ! gn_get_arg_gchar_fix(XBUF, B, I, type_str) ) return FALSE;


### PR DESCRIPTION
Future compilers will not support implicit function declarations by default, so add more function prototypes to the gtnode.h header file. Add a forward declaration of gn_get_arg_gtype to gtknode_marshal.c (as it is not used outside that file).  Include <ctype.h> for isupper and tolower.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
